### PR TITLE
Fix roller commands

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -56,10 +56,10 @@ public class RobotContainer {
    */
   private void configureBindings() {
     // Set input A from driver controller to run ejectCommand
-    rollerSubsystem.ejectCommand(true);
+    driverController.a().whileTrue(rollerSubsystem.ejectCommand());
 
     // Set input B from driver controller to run intakeCommand
-    driverController.b().onTrue(rollerSubsystem.stopRoller());
+    driverController.b().whileTrue(rollerSubsystem.intakeCommand());
 
     /// Set driveSUbystem's default Command to be arcadeDrive
     driveSubsystem.setDefaultCommand(

--- a/src/main/java/frc/robot/subsystems/CANRollerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CANRollerSubsystem.java
@@ -43,16 +43,12 @@ public class CANRollerSubsystem extends SubsystemBase {
 
   // Run Roller at given speed
   public Command runRollerCommand(double percent) {
-    return Commands.run(() -> rollerMotor.set(percent));
+    return Commands.run(() -> rollerMotor.set(percent)).finallyDo(() -> rollerMotor.set(0.0));
   }
 
   // Scoring method
-  public Command ejectCommand(boolean triggerPressed) {
-    if (triggerPressed) {
-      return runRollerCommand(RollerConstants.ROLLER_EJECT_PERCENT);
-    } else {
-      return stopRoller();
-    }
+  public Command ejectCommand() {
+    return runRollerCommand(RollerConstants.ROLLER_EJECT_PERCENT);
   }
 
   public Command intakeCommand() {


### PR DESCRIPTION
## Justification
The rollers would not turn in the latest main commit.
Checking earlier commits did not have a great roller experience.
( The rollers would start running and never stop when one button was pushed, and would reverse and never stop when pushing another button )

## Implementation
Changed the buttons to respond to whileTrue, and change the roller commands to utilize a finallyDo decorator to stop the motors when the button is released.

## Testing Done
Tested on the robot.  Team tested during a drive practice.